### PR TITLE
[PSEC-630] Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @docker/secure-artifacts


### PR DESCRIPTION

The Docker GitHub organization is establishing ownership of repositories through CODEOWNERS.

For more information, see the [Security Decision Log](https://www.notion.so/dockerinc/GitHub-Branch-Protection-Policy-39a276d66be64d9a8082645000a2cbe2).

What we are asking from teams:
1) Review that the assigned team owner is correct and has write access to the repository.

2) Merge this pull request.

3) Update the branch protection rules of the repository to have, _at minimum_, the following settings selected:
    - **Require a pull request before merging**: true
    - **Require approvals**: 1
    - **Require review from Code Owners**: true
    - **Do not allow bypassing the above settings**: true
    - **Allow force pushes**: false

If you don't have the necessary permissions to perform some of the above steps, please reach out to #team-product-security or #security-champions on slack for help.