### PR TITLE
fix: default targets url for mirroring

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -19,14 +19,15 @@ jobs:
           username: dockerpublicbot
           password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
       - name: Mirror metadata
-        uses: docker/go-tuf-mirror/actions/metadata@d27d67e69f43b48945f03378f66f66e40687f39b # v0.1.10
+        uses: docker/go-tuf-mirror/actions/metadata@5f582e994a760a9d839a3845d7974f1c2a2dc006 # v0.1.10-patch
         with:
+          targets: https://docker.github.io/tuf/targets
           source: https://docker.github.io/tuf/metadata
           destination: docker://docker/tuf-metadata:latest
           tuf-root: prod
           flags: "-f"
       - name: Mirror targets
-        uses: docker/go-tuf-mirror/actions/targets@d27d67e69f43b48945f03378f66f66e40687f39b # v0.1.10
+        uses: docker/go-tuf-mirror/actions/targets@5f582e994a760a9d839a3845d7974f1c2a2dc006 # v0.1.10-patch
         with:
           metadata: https://docker.github.io/tuf/metadata
           source: https://docker.github.io/tuf/targets


### PR DESCRIPTION
## Summary
We added `version-constraints` checker to the mirror TUF client which requires the metadata job to download a target where it previously didn't need a targets URL. 

This resulted in the mirror TUF client using the default targets URL which (at the time) pointed to `tuf-staging`. 

This change adds an arg to the metadata action to specify the appropriate targets URL for downloading the `version-constraints` file (and any other target files that may be needed in the future for mirroring metadata).

## Bug
metadata mirroring action using default targets URL when a different root is selected:
https://github.com/docker/tuf/actions/runs/9893115656/job/27327454247#step:4:12