### PR TITLE
chore: fix public secret access

### DIFF
--- a/.github/workflows/update-doi-policy.yml
+++ b/.github/workflows/update-doi-policy.yml
@@ -10,13 +10,6 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - name: Generate GitHub App Token
-        id: ro-token
-        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
-        with:
-          app-id: ${{ vars.DOCKER_READ_APP_ID }}
-          private-key: ${{ secrets.DOCKER_READ_APP_PRIVATE_KEY }}
-          repositories: "doi-image-policy"
-      - name: Generate GitHub App Token
         id: rw-token
         uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
         with:
@@ -24,7 +17,6 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - id: doi-image-policy-release
         run: |
-          export GH_TOKEN=${{ steps.ro-token.outputs.token }}
           RESULT=$(gh release view -R docker/doi-image-policy --json tagName,body)
           TAG_NAME=$(echo $RESULT | jq -r .tagName)
           BODY=$(echo $RESULT | jq -r .body)
@@ -39,7 +31,6 @@ jobs:
         with:
           repository: "docker/doi-image-policy"
           ref: ${{ steps.doi-image-policy-release.outputs.release }}
-          token: ${{ steps.ro-token.outputs.token }}
           path: doi-image-policy
       - name: Checkout tuf
         uses: actions/checkout@v4

--- a/.github/workflows/update-rekor-keys.yml
+++ b/.github/workflows/update-rekor-keys.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: dockerbuildbot
-          password: ${{ secrets.DOCKERBUILDBOT_READ_PAT }}
+          username: dockerpublicbot
+          password: ${{ secrets.DOCKERPUBLICBOT_READ_PAT }}
       - name: Checkout tuf
         id: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Now that this repo is public, we need to use `dockerpublicbot` for Docker Hub access as the previous bot user account's PAT is not available in public repos.

Also remove use of Docker Read App - we also no longer have access to the token and we don't need it anyway as the DOI policy repo is also public now.